### PR TITLE
feat: implement Task 2.1.8 - Label Component

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -439,10 +439,10 @@
 
 #### Task 2.1.8: Label Component
 
-- [ ] Create `src/components/ui/label/Label.vue`
-- [ ] Use Radix Vue Label
-- [ ] Basic styling
-- [ ] Required mark display feature
+- [x] Create `src/components/ui/label/Label.vue`
+- [x] Use Radix Vue Label
+- [x] Basic styling
+- [x] Required mark display feature
 
 #### Task 2.1.9: FieldWrapper Component
 

--- a/apps/vue-vite/src/components/ui/label/Label.vue
+++ b/apps/vue-vite/src/components/ui/label/Label.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { Label as LabelPrimitive } from 'radix-vue'
+import { computed } from 'vue'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/utils/cn'
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+)
+
+interface LabelProps {
+  class?: string
+  asChild?: boolean
+  htmlFor?: string
+  required?: boolean
+}
+
+const props = defineProps<LabelProps>()
+
+const computedClass = computed(() => cn(labelVariants(), props.class))
+</script>
+
+<template>
+  <LabelPrimitive :class="computedClass" :as-child="asChild" :for="htmlFor">
+    <slot />
+    <span v-if="required" class="text-red-500 ml-1" aria-label="required">*</span>
+  </LabelPrimitive>
+</template>

--- a/apps/vue-vite/src/components/ui/label/Label.vue
+++ b/apps/vue-vite/src/components/ui/label/Label.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Label as LabelPrimitive } from 'radix-vue'
 import { computed } from 'vue'
-import { cva, type VariantProps } from 'class-variance-authority'
+import { cva } from 'class-variance-authority'
 import { cn } from '@/utils/cn'
 
 const labelVariants = cva(

--- a/apps/vue-vite/src/components/ui/label/index.ts
+++ b/apps/vue-vite/src/components/ui/label/index.ts
@@ -1,0 +1,1 @@
+export { default as Label } from './Label.vue'


### PR DESCRIPTION
## Summary

Implement Label component with Radix Vue primitives as part of Task 2.1.8.

- ✅ Create `src/components/ui/label/Label.vue` with Radix Vue Label
- ✅ Add basic styling using class-variance-authority
- ✅ Implement required mark display feature (red asterisk with aria-label)
- ✅ Add TypeScript types for props
- ✅ Create index.ts for component exports

## Implementation Details

The Label component provides:
- Radix Vue Label primitive integration
- CVA-based styling with peer-disabled states
- Optional `required` prop to display a red asterisk (*)
- TypeScript type safety
- Accessibility support with aria-label

## Test Plan

- [ ] Verify Label renders correctly
- [ ] Verify `required` prop displays red asterisk
- [ ] Verify `htmlFor` prop connects to form inputs
- [ ] Verify accessibility attributes are present
- [ ] Verify styling matches design system

🤖 Generated with [Claude Code](https://claude.com/claude-code)