### PR TITLE
feat: implement Task 2.4.3 - FormDrawer Component

### DIFF
--- a/MIGRATION_PLAN.md
+++ b/MIGRATION_PLAN.md
@@ -665,16 +665,16 @@
 
 #### Task 2.4.3: FormDrawer Component
 
-- [ ] Create `src/components/ui/form-drawer/FormDrawer.vue`
-- [ ] Define Props
-  - [ ] `open`, `title`, `submitText`, `isLoading`
-- [ ] Define Emits: `close`, `submit`
-- [ ] Use Drawer component
-- [ ] Form slot
-- [ ] Submit/cancel buttons
-- [ ] Loading state
-- [ ] Create Storybook stories
-- [ ] Create Vitest unit tests
+- [x] Create `src/components/ui/form-drawer/FormDrawer.vue`
+- [x] Define Props
+  - [x] `open`, `title`, `submitText`, `isLoading`
+- [x] Define Emits: `close`, `submit`
+- [x] Use Drawer component
+- [x] Form slot
+- [x] Submit/cancel buttons
+- [x] Loading state
+- [x] Create Storybook stories
+- [x] Create Vitest unit tests
 
 ---
 

--- a/apps/vue-vite/src/components/ui/form-drawer/FormDrawer.stories.ts
+++ b/apps/vue-vite/src/components/ui/form-drawer/FormDrawer.stories.ts
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import { Button } from '@/components/ui/button'
+import { DrawerTrigger } from '@/components/ui/drawer'
+
+import { FormDrawer } from './'
+
+const meta: Meta<typeof FormDrawer> = {
+  component: FormDrawer,
+  render: (args) => ({
+    components: {
+      Button,
+      DrawerTrigger,
+      FormDrawer,
+    },
+    setup() {
+      const isOpen = ref(false)
+      const isLoading = ref(false)
+      const isDone = ref(false)
+
+      const handleSubmit = () => {
+        isLoading.value = true
+        // Simulate API call
+        setTimeout(() => {
+          isLoading.value = false
+          isDone.value = true
+          // Reset isDone after drawer closes
+          setTimeout(() => {
+            isDone.value = false
+          }, 100)
+        }, 1500)
+      }
+
+      const handleClose = () => {
+        isOpen.value = false
+      }
+
+      return { isOpen, isLoading, isDone, handleSubmit, handleClose, args }
+    },
+    template: `
+      <FormDrawer
+        :open="isOpen"
+        @update:open="(val) => isOpen = val"
+        :title="args.title"
+        :submitText="args.submitText"
+        :isLoading="isLoading"
+        :isDone="isDone"
+        @submit="handleSubmit"
+        @close="handleClose"
+      >
+        <template #trigger>
+          <DrawerTrigger asChild>
+            <Button variant="outline">Open Form Drawer</Button>
+          </DrawerTrigger>
+        </template>
+        <div class="space-y-4 py-4">
+          <div class="space-y-2">
+            <label for="name" class="text-sm font-medium">Name</label>
+            <input
+              id="name"
+              type="text"
+              placeholder="Enter your name"
+              class="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            />
+          </div>
+          <div class="space-y-2">
+            <label for="email" class="text-sm font-medium">Email</label>
+            <input
+              id="email"
+              type="email"
+              placeholder="Enter your email"
+              class="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            />
+          </div>
+          <div class="space-y-2">
+            <label for="message" class="text-sm font-medium">Message</label>
+            <textarea
+              id="message"
+              rows="4"
+              placeholder="Enter your message"
+              class="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            ></textarea>
+          </div>
+        </div>
+      </FormDrawer>
+    `,
+  }),
+}
+
+export default meta
+
+type Story = StoryObj<typeof FormDrawer>
+
+export const Default: Story = {
+  args: {
+    title: 'Create New Item',
+    submitText: 'Submit',
+  },
+}
+
+export const CustomSubmitText: Story = {
+  args: {
+    title: 'Edit Profile',
+    submitText: 'Save Changes',
+  },
+}
+
+export const LongForm: Story = {
+  args: {
+    title: 'Complete Registration',
+    submitText: 'Register',
+  },
+}

--- a/apps/vue-vite/src/components/ui/form-drawer/FormDrawer.test.ts
+++ b/apps/vue-vite/src/components/ui/form-drawer/FormDrawer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import FormDrawer from './FormDrawer.vue'
 

--- a/apps/vue-vite/src/components/ui/form-drawer/FormDrawer.test.ts
+++ b/apps/vue-vite/src/components/ui/form-drawer/FormDrawer.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FormDrawer from './FormDrawer.vue'
+
+describe('FormDrawer', () => {
+  let container: HTMLElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    container.id = 'test-container'
+    document.body.appendChild(container)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(container)
+  })
+
+  it('renders with default props when open', async () => {
+    const wrapper = mount(FormDrawer, {
+      props: {
+        open: true,
+        title: 'Test Form',
+      },
+      attachTo: container,
+    })
+
+    await wrapper.vm.$nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const content = document.body.textContent
+    expect(content).toContain('Test Form')
+    expect(content).toContain('Close')
+    expect(content).toContain('Submit')
+
+    wrapper.unmount()
+  })
+
+  it('does not render drawer content when open is false', () => {
+    const wrapper = mount(FormDrawer, {
+      props: {
+        open: false,
+        title: 'Test Form',
+      },
+    })
+
+    const drawerContent = document.querySelector('[role="dialog"]')
+    expect(drawerContent).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it('emits submit event when submit button is clicked', async () => {
+    const wrapper = mount(FormDrawer, {
+      props: {
+        open: true,
+        title: 'Test Form',
+      },
+      attachTo: container,
+    })
+
+    await wrapper.vm.$nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const buttons = document.querySelectorAll('button')
+    const submitButton = Array.from(buttons).find((btn) => btn.textContent?.trim() === 'Submit')
+
+    expect(submitButton).toBeDefined()
+    submitButton?.click()
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('submit')).toBeTruthy()
+    expect(wrapper.emitted('submit')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('emits close event when close button is clicked', async () => {
+    const wrapper = mount(FormDrawer, {
+      props: {
+        open: true,
+        title: 'Test Form',
+      },
+      attachTo: container,
+    })
+
+    await wrapper.vm.$nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const buttons = document.querySelectorAll('button')
+    const closeButton = Array.from(buttons).find((btn) => btn.textContent?.trim() === 'Close')
+
+    expect(closeButton).toBeDefined()
+    closeButton?.click()
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('close')).toBeTruthy()
+    expect(wrapper.emitted('update:open')).toBeTruthy()
+
+    wrapper.unmount()
+  })
+
+  it('accepts custom submitText', async () => {
+    const wrapper = mount(FormDrawer, {
+      props: {
+        open: true,
+        title: 'Test Form',
+        submitText: 'Save Changes',
+      },
+      attachTo: container,
+    })
+
+    await wrapper.vm.$nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const content = document.body.textContent
+    expect(content).toContain('Save Changes')
+
+    wrapper.unmount()
+  })
+
+  it('displays loading state on submit button when isLoading is true', async () => {
+    const wrapper = mount(FormDrawer, {
+      props: {
+        open: true,
+        title: 'Test Form',
+        isLoading: true,
+      },
+      attachTo: container,
+    })
+
+    await wrapper.vm.$nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const buttons = document.querySelectorAll('button')
+    const submitButton = Array.from(buttons).find((btn) =>
+      btn.textContent?.includes('Submit'),
+    )
+
+    expect(submitButton?.hasAttribute('disabled')).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('closes drawer when isDone becomes true', async () => {
+    const wrapper = mount(FormDrawer, {
+      props: {
+        open: true,
+        title: 'Test Form',
+        isDone: false,
+      },
+      attachTo: container,
+    })
+
+    await wrapper.vm.$nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    // Update isDone to true
+    await wrapper.setProps({ isDone: true })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('update:open')).toBeTruthy()
+    expect(wrapper.emitted('close')).toBeTruthy()
+
+    const lastEmit = wrapper.emitted('update:open')
+    expect(lastEmit?.[lastEmit.length - 1]).toEqual([false])
+
+    wrapper.unmount()
+  })
+
+  it('renders slot content', async () => {
+    const wrapper = mount(FormDrawer, {
+      props: {
+        open: true,
+        title: 'Test Form',
+      },
+      slots: {
+        default: '<div class="test-content">Form Content</div>',
+      },
+      attachTo: container,
+    })
+
+    await wrapper.vm.$nextTick()
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    const content = document.body.textContent
+    expect(content).toContain('Form Content')
+
+    wrapper.unmount()
+  })
+
+  it('renders trigger slot content', async () => {
+    const wrapper = mount(FormDrawer, {
+      props: {
+        open: false,
+        title: 'Test Form',
+      },
+      slots: {
+        trigger: '<button class="test-trigger">Open Drawer</button>',
+      },
+    })
+
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.html()).toContain('Open Drawer')
+
+    wrapper.unmount()
+  })
+})

--- a/apps/vue-vite/src/components/ui/form-drawer/FormDrawer.vue
+++ b/apps/vue-vite/src/components/ui/form-drawer/FormDrawer.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { watch } from 'vue'
+import { Button } from '../button'
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from '../drawer'
+
+export interface FormDrawerProps {
+  open: boolean
+  title: string
+  submitText?: string
+  isLoading?: boolean
+  isDone?: boolean
+}
+
+const props = withDefaults(defineProps<FormDrawerProps>(), {
+  submitText: 'Submit',
+  isLoading: false,
+  isDone: false,
+})
+
+const emit = defineEmits<{
+  close: []
+  submit: []
+  'update:open': [value: boolean]
+}>()
+
+const handleOpenChange = (isOpen: boolean) => {
+  if (!isOpen) {
+    emit('close')
+  }
+  emit('update:open', isOpen)
+}
+
+// Close drawer when form submission is done
+watch(
+  () => props.isDone,
+  (newValue) => {
+    if (newValue) {
+      emit('update:open', false)
+      emit('close')
+    }
+  },
+)
+</script>
+
+<template>
+  <Drawer :open="open" @update:open="handleOpenChange">
+    <slot name="trigger"></slot>
+    <DrawerContent
+      class="flex max-w-[800px] flex-col justify-between sm:max-w-[540px]"
+      side="right"
+    >
+      <div class="flex flex-col">
+        <DrawerHeader>
+          <DrawerTitle>{{ title }}</DrawerTitle>
+        </DrawerHeader>
+        <div class="px-6">
+          <slot></slot>
+        </div>
+      </div>
+      <DrawerFooter>
+        <DrawerClose as-child>
+          <Button variant="outline" type="button"> Close </Button>
+        </DrawerClose>
+        <Button type="submit" :is-loading="isLoading" @click="emit('submit')">
+          {{ submitText }}
+        </Button>
+      </DrawerFooter>
+    </DrawerContent>
+  </Drawer>
+</template>

--- a/apps/vue-vite/src/components/ui/form-drawer/FormDrawer.vue
+++ b/apps/vue-vite/src/components/ui/form-drawer/FormDrawer.vue
@@ -68,7 +68,7 @@ watch(
         <DrawerClose as-child>
           <Button variant="outline" type="button"> Close </Button>
         </DrawerClose>
-        <Button type="submit" :is-loading="isLoading" @click="emit('submit')">
+        <Button type="submit" :is-loading="isLoading" :disabled="isLoading" @click="emit('submit')">
           {{ submitText }}
         </Button>
       </DrawerFooter>

--- a/apps/vue-vite/src/components/ui/form-drawer/index.ts
+++ b/apps/vue-vite/src/components/ui/form-drawer/index.ts
@@ -1,0 +1,2 @@
+export { default as FormDrawer } from './FormDrawer.vue'
+export type { FormDrawerProps } from './FormDrawer.vue'


### PR DESCRIPTION
## Summary

- Implemented FormDrawer component for form presentations in a drawer interface
- Added comprehensive props including open, title, submitText, isLoading, and isDone
- Integrated with existing Drawer component from Radix Vue
- Auto-close functionality when form submission completes

## Implementation Details

### Component Features
- **Props**: open, title, submitText (default: "Submit"), isLoading, isDone
- **Emits**: close, submit, update:open
- **Slots**: default (form content), trigger (drawer trigger button)
- **Auto-close**: Automatically closes when isDone prop becomes true
- **Loading state**: Submit button shows loading spinner when isLoading is true

### Files Created
- `apps/vue-vite/src/components/ui/form-drawer/FormDrawer.vue` - Main component
- `apps/vue-vite/src/components/ui/form-drawer/index.ts` - Export file
- `apps/vue-vite/src/components/ui/form-drawer/FormDrawer.stories.ts` - Storybook stories
- `apps/vue-vite/src/components/ui/form-drawer/FormDrawer.test.ts` - Vitest unit tests

### Test Coverage
- Basic rendering with open/closed states
- Submit and close event emissions
- Custom submitText prop
- Loading state handling
- Auto-close on isDone
- Slot rendering (default and trigger slots)

### Updated
- `MIGRATION_PLAN.md` - Marked Task 2.4.3 as completed

## Test Plan

- [x] Component renders correctly when open
- [x] Component hides when closed
- [x] Submit event is emitted on button click
- [x] Close event is emitted when closing
- [x] Custom submit text is displayed
- [x] Loading state disables and shows spinner on submit button
- [x] Drawer closes automatically when isDone becomes true
- [x] Slots render correctly
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)