### PR TITLE
chore(ci): update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/db-reset.yml
+++ b/.github/workflows/db-reset.yml
@@ -24,11 +24,11 @@ jobs:
         working-directory: ./apps/nuxt
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: "pnpm"

--- a/.github/workflows/nuxt-ci.yml
+++ b/.github/workflows/nuxt-ci.yml
@@ -24,11 +24,11 @@ jobs:
         working-directory: ./apps/nuxt
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: "pnpm"
@@ -50,11 +50,11 @@ jobs:
         working-directory: ./apps/nuxt
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: "pnpm"
@@ -66,7 +66,7 @@ jobs:
         run: pnpm test:e2e:ci
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: apps/nuxt/playwright/playwright-report/

--- a/.github/workflows/vue-vite-ci.yml
+++ b/.github/workflows/vue-vite-ci.yml
@@ -19,9 +19,9 @@ jobs:
       run:
         working-directory: ./apps/vue-vite
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: "pnpm"
@@ -44,9 +44,9 @@ jobs:
       run:
         working-directory: ./apps/vue-vite
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
           cache: "pnpm"
@@ -58,7 +58,7 @@ jobs:
         run: pnpm exec playwright install --with-deps
       - name: Run Playwright tests
         run: pnpm run test:e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
## Summary
- Update actions/checkout from v4 to v6
- Update actions/setup-node from v4 to v6
- Update actions/upload-artifact from v4 to v5

## Files changed
- `.github/workflows/nuxt-ci.yml`
- `.github/workflows/vue-vite-ci.yml`
- `.github/workflows/db-reset.yml`