### PR TITLE
fix(security): override systeminformation to 5.30.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "jiti": "2.6.1",
       "prisma": "npm:empty-npm-package@1.0.0",
       "@prisma/client": "npm:empty-npm-package@1.0.0",
+      "basic-ftp": "^5.2.1",
       "esbuild": ">=0.25.0",
       "@types/node": "^24.10.3"
     }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "prisma": "npm:empty-npm-package@1.0.0",
       "@prisma/client": "npm:empty-npm-package@1.0.0",
       "basic-ftp": "^5.2.1",
+      "systeminformation": "^5.30.8",
       "esbuild": ">=0.25.0",
       "@types/node": "^24.10.3"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   jiti: 2.6.1
   prisma: npm:empty-npm-package@1.0.0
   '@prisma/client': npm:empty-npm-package@1.0.0
+  basic-ftp: ^5.2.1
   esbuild: '>=0.25.0'
   '@types/node': ^24.10.3
 
@@ -4887,10 +4888,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.1.0:
-    resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
+  basic-ftp@5.2.2:
+    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
@@ -13888,7 +13888,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.7: {}
 
-  basic-ftp@5.1.0: {}
+  basic-ftp@5.2.2: {}
 
   bcryptjs@3.0.3: {}
 
@@ -15454,7 +15454,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.1.0
+      basic-ftp: 5.2.2
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   prisma: npm:empty-npm-package@1.0.0
   '@prisma/client': npm:empty-npm-package@1.0.0
   basic-ftp: ^5.2.1
+  systeminformation: ^5.30.8
   esbuild: '>=0.25.0'
   '@types/node': ^24.10.3
 
@@ -8950,8 +8951,8 @@ packages:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
 
-  systeminformation@5.30.7:
-    resolution: {integrity: sha512-33B/cftpaWdpvH+Ho9U1b08ss8GQuLxrWHelbJT1yw4M48Taj8W3ezcPuaLoIHZz5V6tVHuQPr5BprEfnBLBMw==}
+  systeminformation@5.31.5:
+    resolution: {integrity: sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -17330,7 +17331,7 @@ snapshots:
       async: 3.2.6
       debug: 4.4.3
       pidusage: 2.0.21
-      systeminformation: 5.30.7
+      systeminformation: 5.31.5
       tx2: 1.0.5
     transitivePeerDependencies:
       - supports-color
@@ -18413,7 +18414,7 @@ snapshots:
 
   system-architecture@0.1.0: {}
 
-  systeminformation@5.30.7:
+  systeminformation@5.31.5:
     optional: true
 
   tagged-tag@1.0.0: {}


### PR DESCRIPTION
## Summary
- Remediate Dependabot alert 138 for transitive `systeminformation` vulnerability (`< 5.30.8`).
- Add a root `pnpm.overrides` entry for `systeminformation` to enforce a patched version range.
- Update lockfile resolution from `systeminformation@5.30.7` to `systeminformation@5.31.5` in the `pm2 -> pm2-sysmonit` chain.

## Verification
- Confirmed `pnpm-lock.yaml` contains no `systeminformation@5.30.7`.
- Ran `pnpm -r why systeminformation` and verified only `systeminformation@5.31.5` is resolved.
- Ran `pnpm --filter bulletproof-vue-vite lint` successfully.
- Ran `pnpm --filter bulletproof-vue-vite type-check` successfully.