### PR TITLE
fix(security): override editorconfig to resolve minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "prisma": "npm:empty-npm-package@1.0.0",
       "@prisma/client": "npm:empty-npm-package@1.0.0",
       "basic-ftp": "^5.2.1",
+      "editorconfig": "^1.0.7",
       "systeminformation": "^5.30.8",
       "esbuild": ">=0.25.0",
       "@types/node": "^24.10.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   prisma: npm:empty-npm-package@1.0.0
   '@prisma/client': npm:empty-npm-package@1.0.0
   basic-ftp: ^5.2.1
+  editorconfig: ^1.0.7
   systeminformation: ^5.30.8
   esbuild: '>=0.25.0'
   '@types/node': ^24.10.3
@@ -5748,8 +5749,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  editorconfig@1.0.4:
-    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
+  editorconfig@1.0.7:
+    resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -7372,10 +7373,6 @@ packages:
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
-
-  minimatch@9.0.1:
-    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
-    engines: {node: '>=16 || 14 >=14.17'}
 
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
@@ -14633,11 +14630,11 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  editorconfig@1.0.4:
+  editorconfig@1.0.7:
     dependencies:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
-      minimatch: 9.0.1
+      minimatch: 9.0.9
       semver: 7.7.4
 
   ee-first@1.1.1: {}
@@ -16006,7 +16003,7 @@ snapshots:
   js-beautify@1.15.4:
     dependencies:
       config-chain: 1.1.13
-      editorconfig: 1.0.4
+      editorconfig: 1.0.7
       glob: 10.5.0
       js-cookie: 3.0.5
       nopt: 7.2.1
@@ -16431,10 +16428,6 @@ snapshots:
       brace-expansion: 5.0.4
 
   minimatch@5.1.9:
-    dependencies:
-      brace-expansion: 2.0.2
-
-  minimatch@9.0.1:
     dependencies:
       brace-expansion: 2.0.2
 


### PR DESCRIPTION
## Summary
- Remediate Dependabot alert #145 (`minimatch` ReDoS in vulnerable 9.x range).
- Add a root `pnpm.overrides` entry for `editorconfig` to force `^1.0.7`.
- Update lockfile so the vulnerable path `editorconfig@1.0.4 -> minimatch@9.0.1` is replaced with `editorconfig@1.0.7 -> minimatch@9.0.9`.

## Verification
- Confirmed `pnpm-lock.yaml` contains no `minimatch@9.0.1`.
- Confirmed `pnpm-lock.yaml` contains no `editorconfig@1.0.4`.
- Ran `pnpm -r why minimatch` and verified 9.x resolves to `9.0.9` (patched), with `9.0.1` removed.
- Ran `pnpm --filter bulletproof-vue-vite lint` successfully.
- Ran `pnpm --filter bulletproof-vue-vite type-check` successfully.