### PR TITLE
fix(security): override serialize-javascript to 7.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
       "@prisma/client": "npm:empty-npm-package@1.0.0",
       "basic-ftp": "^5.2.1",
       "editorconfig": "^1.0.7",
+      "serialize-javascript": "^7.0.5",
       "systeminformation": "^5.30.8",
       "esbuild": ">=0.25.0",
       "@types/node": "^24.10.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   '@prisma/client': npm:empty-npm-package@1.0.0
   basic-ftp: ^5.2.1
   editorconfig: ^1.0.7
+  serialize-javascript: ^7.0.5
   systeminformation: ^5.30.8
   esbuild: '>=0.25.0'
   '@types/node': ^24.10.3
@@ -8332,9 +8333,6 @@ packages:
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -8630,8 +8628,9 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   seroval@1.5.1:
     resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
@@ -12104,7 +12103,7 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@4.60.1)':
     dependencies:
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       smob: 1.6.1
       terser: 5.46.0
     optionalDependencies:
@@ -17693,10 +17692,6 @@ snapshots:
 
   radix3@1.1.2: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   range-parser@1.2.1: {}
 
   raw-body@2.5.3:
@@ -18052,9 +18047,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   seroval@1.5.1: {}
 


### PR DESCRIPTION
## Summary
- Remediate transitive `serialize-javascript` vulnerabilities by updating to `7.0.5`.
- Add a root `pnpm.overrides` entry for `serialize-javascript` to enforce `^7.0.5`.
- Update lockfile resolution so the vulnerable `serialize-javascript@6.0.2` in the Nuxt/Nitro chain is replaced with `serialize-javascript@7.0.5`.

## Related Alerts
- [Alert#154](https://github.com/hirotaka/pragmatic-nuxt/security/dependabot/154)
- [Alert#198](https://github.com/hirotaka/pragmatic-nuxt/security/dependabot/198)

## Verification
- Confirmed `pnpm-lock.yaml` contains no `serialize-javascript@6.0.2`.
- Ran `pnpm -r why serialize-javascript` and verified only `serialize-javascript@7.0.5` is resolved.
- Ran `pnpm --filter bulletproof-nuxt lint` successfully.
- Ran `pnpm --filter bulletproof-nuxt type-check`; this fails in current environment with `vue-router/volar/sfc-route-blocks` export error (pre-existing toolchain issue), unrelated to this dependency update.