### PR TITLE
fix(security): override dompurify to 3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
       "@prisma/client": "npm:empty-npm-package@1.0.0",
       "basic-ftp": "^5.2.1",
       "editorconfig": "^1.0.7",
+      "dompurify": "3.3.2",
       "serialize-javascript": "^7.0.5",
       "systeminformation": "^5.30.8",
       "esbuild": ">=0.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   '@prisma/client': npm:empty-npm-package@1.0.0
   basic-ftp: ^5.2.1
   editorconfig: ^1.0.7
+  dompurify: 3.3.2
   serialize-javascript: ^7.0.5
   systeminformation: ^5.30.8
   esbuild: '>=0.25.0'
@@ -5614,8 +5615,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  dompurify@3.3.2:
+    resolution: {integrity: sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==}
+    engines: {node: '>=20'}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -14574,7 +14576,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.1:
+  dompurify@3.3.2:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -19080,7 +19082,7 @@ snapshots:
 
   vue-dompurify-html@5.3.0(vue@3.5.31(typescript@6.0.2)):
     dependencies:
-      dompurify: 3.3.1
+      dompurify: 3.3.2
       vue: 3.5.31(typescript@6.0.2)
 
   vue-eslint-parser@10.4.0(eslint@10.1.0(jiti@2.6.1)):


### PR DESCRIPTION
## Summary
- Remediate transitive `dompurify` vulnerabilities by updating to `3.3.2`.
- Add a root `pnpm.overrides` entry for `dompurify` pinned to `3.3.2`.
- Update lockfile resolution from `dompurify@3.3.1` to `dompurify@3.3.2` in the `vue-dompurify-html` dependency path across workspace apps.

## Related Alerts
- [Alert#155](https://github.com/hirotaka/pragmatic-nuxt/security/dependabot/155)
- [Alert#199](https://github.com/hirotaka/pragmatic-nuxt/security/dependabot/199)
- [Alert#202](https://github.com/hirotaka/pragmatic-nuxt/security/dependabot/202)
- [Alert#203](https://github.com/hirotaka/pragmatic-nuxt/security/dependabot/203)

## Verification
- Confirmed `pnpm-lock.yaml` contains no `dompurify@3.3.1`.
- Confirmed `pnpm-lock.yaml` resolves `dompurify@3.3.2`.
- Ran `pnpm -r why dompurify` and verified only `dompurify@3.3.2` is present.
- Ran `pnpm --filter bulletproof-vue-vite lint` successfully.
- Ran `pnpm --filter bulletproof-vue-vite type-check` successfully.
- Ran `pnpm --filter bulletproof-nuxt lint` successfully.
- Ran `pnpm --filter bulletproof-nuxt type-check`; this fails in current environment with `vue-router/volar/sfc-route-blocks` export error (pre-existing toolchain issue, unrelated to this dependency update).