### PR TITLE
fix: remediate Dependabot alert #210 for unhead

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "jiti": "2.6.1",
       "prisma": "npm:empty-npm-package@1.0.0",
       "@prisma/client": "npm:empty-npm-package@1.0.0",
+      "@unhead/vue": "2.1.13",
       "basic-ftp": "^5.2.1",
       "editorconfig": "^1.0.7",
       "dompurify": "3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   jiti: 2.6.1
   prisma: npm:empty-npm-package@1.0.0
   '@prisma/client': npm:empty-npm-package@1.0.0
+  '@unhead/vue': 2.1.13
   basic-ftp: ^5.2.1
   editorconfig: ^1.0.7
   dompurify: 3.3.2
@@ -527,13 +528,13 @@ importers:
         version: 1.21.5(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))
       '@regle/nuxt':
         specifier: ^1.0.0
-        version: 1.21.5(magicast@0.5.2)(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)
+        version: 1.21.5(magicast@0.5.2)(typescript@6.0.2)(valibot@1.3.1(typescript@6.0.2))(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)
       '@regle/rules':
         specifier: ^1.0.0
         version: 1.21.5(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))
       '@regle/schemas':
         specifier: ^1.13.0
-        version: 1.21.2(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)
+        version: 1.21.2(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(valibot@1.3.1(typescript@6.0.2))(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -837,8 +838,8 @@ importers:
         specifier: ^5.90.2
         version: 5.96.1(vue@3.5.31(typescript@6.0.2))
       '@unhead/vue':
-        specifier: ^2.0.19
-        version: 2.1.12(vue@3.5.31(typescript@6.0.2))
+        specifier: 2.1.13
+        version: 2.1.13(vue@3.5.31(typescript@6.0.2))
       '@vee-validate/zod':
         specifier: ^4.15.1
         version: 4.15.1(vue@3.5.31(typescript@6.0.2))(zod@3.25.76)
@@ -4212,8 +4213,8 @@ packages:
     resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@unhead/vue@2.1.12':
-    resolution: {integrity: sha512-zEWqg0nZM8acpuTZE40wkeUl8AhIe0tU0OkilVi1D4fmVjACrwoh5HP6aNqJ8kUnKsoy6D+R3Vi/O+fmdNGO7g==}
+  '@unhead/vue@2.1.13':
+    resolution: {integrity: sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==}
     peerDependencies:
       vue: 3.5.31
 
@@ -9211,9 +9212,6 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
-  unhead@2.1.12:
-    resolution: {integrity: sha512-iTHdWD9ztTunOErtfUFk6Wr11BxvzumcYJ0CzaSCBUOEtg+DUZ9+gnE99i8QkLFT2q1rZD48BYYGXpOZVDLYkA==}
-
   unhead@2.1.13:
     resolution: {integrity: sha512-jO9M1sI6b2h/1KpIu4Jeu+ptumLmUKboRRLxys5pYHFeT+lqTzfNHbYUX9bxVDhC1FBszAGuWcUVlmvIPsah8Q==}
 
@@ -9386,6 +9384,14 @@ packages:
   v8flags@4.0.1:
     resolution: {integrity: sha512-fcRLaS4H/hrZk9hYwbdRM35D0U8IYMfEClhXxCivOojl+yTRAZH3Zy2sSy6qVCiGbV9YAtPssP6jaChqC9vPCg==}
     engines: {node: '>= 10.13.0'}
+
+  valibot@1.3.1:
+    resolution: {integrity: sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -11403,7 +11409,7 @@ snapshots:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@unhead/vue': 2.1.12(vue@3.5.31(typescript@6.0.2))
+      '@unhead/vue': 2.1.13(vue@3.5.31(typescript@6.0.2))
       '@vue/shared': 3.5.30
       consola: 3.4.2
       defu: 6.1.4
@@ -12007,14 +12013,14 @@ snapshots:
     optionalDependencies:
       pinia: 3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))
 
-  '@regle/nuxt@1.21.5(magicast@0.5.2)(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)':
+  '@regle/nuxt@1.21.5(magicast@0.5.2)(typescript@6.0.2)(valibot@1.3.1(typescript@6.0.2))(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)':
     dependencies:
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
       '@nuxt/schema': 4.3.1
       '@regle/core': 1.21.5(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))
       '@regle/rules': 1.21.5(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))
     optionalDependencies:
-      '@regle/schemas': 1.21.5(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)
+      '@regle/schemas': 1.21.5(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(valibot@1.3.1(typescript@6.0.2))(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)
       pinia: 3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2))
     transitivePeerDependencies:
       - arktype
@@ -12040,25 +12046,27 @@ snapshots:
       - pinia
       - vue
 
-  '@regle/schemas@1.21.2(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)':
+  '@regle/schemas@1.21.2(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(valibot@1.3.1(typescript@6.0.2))(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)':
     dependencies:
       '@regle/core': 1.21.2(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))
       '@regle/rules': 1.21.2(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))
       '@standard-schema/spec': 1.1.0
       type-fest: 5.5.0
     optionalDependencies:
+      valibot: 1.3.1(typescript@6.0.2)
       zod: 4.3.6
     transitivePeerDependencies:
       - pinia
       - vue
 
-  '@regle/schemas@1.21.5(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)':
+  '@regle/schemas@1.21.5(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(valibot@1.3.1(typescript@6.0.2))(vue@3.5.31(typescript@6.0.2))(zod@4.3.6)':
     dependencies:
       '@regle/core': 1.21.5(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))
       '@regle/rules': 1.21.5(pinia@3.0.4(typescript@6.0.2)(vue@3.5.31(typescript@6.0.2)))(vue@3.5.31(typescript@6.0.2))
       '@standard-schema/spec': 1.1.0
       type-fest: 5.5.0
     optionalDependencies:
+      valibot: 1.3.1(typescript@6.0.2)
       zod: 4.3.6
     transitivePeerDependencies:
       - pinia
@@ -13115,10 +13123,10 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
 
-  '@unhead/vue@2.1.12(vue@3.5.31(typescript@6.0.2))':
+  '@unhead/vue@2.1.13(vue@3.5.31(typescript@6.0.2))':
     dependencies:
-      hookable: 6.0.1
-      unhead: 2.1.12
+      hookable: 6.1.0
+      unhead: 2.1.13
       vue: 3.5.31(typescript@6.0.2)
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -16767,7 +16775,7 @@ snapshots:
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
       '@nuxt/vite-builder': 4.4.2(781b8950f86a6bf0d21df9d61f4b8114)
-      '@unhead/vue': 2.1.12(vue@3.5.31(typescript@6.0.2))
+      '@unhead/vue': 2.1.13(vue@3.5.31(typescript@6.0.2))
       '@vue/shared': 3.5.30
       c12: 3.3.3(magicast@0.5.2)
       chokidar: 5.0.0
@@ -18632,10 +18640,6 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
-  unhead@2.1.12:
-    dependencies:
-      hookable: 6.1.0
-
   unhead@2.1.13:
     dependencies:
       hookable: 6.1.0
@@ -18834,6 +18838,11 @@ snapshots:
   uuid@9.0.1: {}
 
   v8flags@4.0.1: {}
+
+  valibot@1.3.1(typescript@6.0.2):
+    optionalDependencies:
+      typescript: 6.0.2
+    optional: true
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary
- Remediate the transitive `unhead` vulnerability by removing vulnerable `<2.1.13` resolution from Nuxt-side dependency graph.
- Prefer parent dependency updates first, then apply minimal root `pnpm.overrides` to pin `@unhead/vue` to `2.1.13` so all Nuxt paths resolve to patched `unhead`.
- Refresh lockfile to remove `unhead@2.1.12`.

## Related Alert
- https://github.com/hirotaka/pragmatic-nuxt/security/dependabot/210

## Verification
- `pnpm -r why unhead` shows patched resolutions (`unhead@2.1.13` and `unhead@3.0.4`), with no `2.1.12`.
- `pnpm --filter bulletproof-vue-vite lint` passed.
- `pnpm --filter bulletproof-vue-vite type-check` passed.
- `pnpm --filter bulletproof-nuxt lint` passed.
- `pnpm --filter bulletproof-nuxt type-check` fails in current environment with `vue-router/volar/sfc-route-blocks` export error (pre-existing toolchain issue, unrelated to this update).