### PR TITLE
docs: add repository security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+This repository is maintained on the `main` branch.
+
+| Version | Supported |
+| --- | --- |
+| main | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Please do not open public GitHub issues for suspected security vulnerabilities.
+
+Report vulnerabilities privately through GitHub's private vulnerability reporting feature:
+https://github.com/hirotaka/pragmatic-nuxt/security/advisories/new
+
+Include the following when possible:
+- affected area or package
+- reproduction steps
+- potential impact
+- suggested remediation, if known
+
+You should receive an acknowledgement within a reasonable timeframe.


### PR DESCRIPTION
## Summary
- add `.github/SECURITY.md` to define a repository security policy
- document supported version scope (`main` branch)
- provide private vulnerability reporting path via GitHub Security Advisories

## Why
- the Security and quality overview currently shows `Security policy` as disabled
- adding `SECURITY.md` enables the policy and improves repository security metadata